### PR TITLE
ci: route workflows to dedicated self-hosted runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ permissions:
 jobs:
   quality:
     name: Lint, typecheck & unit tests
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, collective-intelligence]
     defaults:
       run:
         working-directory: api

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -21,7 +21,7 @@ permissions:
 jobs:
   dco:
     name: Signed-off-by check
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, collective-intelligence]
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:

--- a/.github/workflows/license-compliance.yml
+++ b/.github/workflows/license-compliance.yml
@@ -22,7 +22,7 @@ permissions:
 jobs:
   spdx-headers:
     name: SPDX header coverage
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, collective-intelligence]
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
@@ -33,7 +33,7 @@ jobs:
 
   reuse:
     name: REUSE compliance
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, collective-intelligence]
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: REUSE lint (machine-verifiable license coverage)

--- a/.github/workflows/release-provenance.yml
+++ b/.github/workflows/release-provenance.yml
@@ -30,7 +30,7 @@ permissions:
 
 jobs:
   provenance:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, collective-intelligence]
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 


### PR DESCRIPTION
## Why

GitHub-hosted runners (`ubuntu-latest`) for the `ailinone` org are currently blocked by an account billing/spending-limit issue ("The job was not started because recent account payments have failed or your spending limit needs to be increased"). This is unrelated to runner capacity and can't be fixed by changing workflow config other than moving off GitHub-hosted runners. Every job in this repo currently targets `ubuntu-latest`, so none of them can run right now.

## What

Provisioned a dedicated ephemeral self-hosted runner for this repo (OS user `actions-collective-intelligence`, container `myoung34/github-runner`, label `collective-intelligence`, docker-group-only, no sudo) on the org's existing Docker Swarm host, following the same pattern already validated for other repos in the org.

Routed every job's `runs-on` from `ubuntu-latest` to `[self-hosted, linux, x64, collective-intelligence]`:

- `ci.yml` — `quality` (Lint, typecheck & unit tests)
- `dco.yml` — `dco` (Signed-off-by check)
- `license-compliance.yml` — `spdx-headers` and `reuse`
- `release-provenance.yml` — `provenance`

No other changes.

## Security note (public repo + self-hosted runner)

This repo is public, and `ci.yml` / `license-compliance.yml` trigger on `pull_request` (including from forks), with `ci.yml` running `pnpm install` + tests and `spdx-headers` running a repo script — i.e. they execute code from the PR branch. GitHub mandates manual "Approve and run" from a maintainer for any workflow run from a public fork that targets a self-hosted runner, regardless of the repo's fork-approval setting, so this doesn't newly expose the runner to unreviewed code — but it does mean external PRs will now sit waiting for a maintainer to review-and-approve the run before checks execute, where previously (once billing is fixed) they'd have run automatically on GitHub-hosted infra. Worth reviewing the diff before approving any first-time-contributor run, given the runner has docker.sock access on the host.

`dco.yml` only inspects commit messages (no code execution) and `release-provenance.yml` only triggers on `release: published` / `workflow_dispatch` (both maintainer-only actions), so neither has this exposure.