### PR TITLE
chore(deps): bump @types/node to 26.1.2, fix the 4 breaks (closes #46)

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -180,7 +180,7 @@
     "@testcontainers/redis": "^12.0.3",
     "@types/bcrypt": "^6.0.0",
     "@types/jsonwebtoken": "^9.0.10",
-    "@types/node": "^20.11.17",
+    "@types/node": "^26.1.2",
     "@types/node-cron": "^3.0.11",
     "@types/nodemailer": "^8.0.1",
     "@types/pdfkit": "^0.17.6",

--- a/api/pnpm-lock.yaml
+++ b/api/pnpm-lock.yaml
@@ -362,8 +362,8 @@ importers:
         specifier: ^9.0.10
         version: 9.0.10
       '@types/node':
-        specifier: ^20.11.17
-        version: 20.19.43
+        specifier: ^26.1.2
+        version: 26.1.2
       '@types/node-cron':
         specifier: ^3.0.11
         version: 3.0.11
@@ -387,7 +387,7 @@ importers:
         version: 6.21.0(eslint@8.57.1)(typescript@5.9.3)
       '@vitest/coverage-v8':
         specifier: 3.2.6
-        version: 3.2.6(vitest@3.2.6(@types/debug@4.1.12)(@types/node@20.19.43)(jiti@2.7.0)(jsdom@28.0.0(@noble/hashes@1.8.0))(tsx@4.23.1)(yaml@2.9.0))
+        version: 3.2.6(vitest@3.2.6(@types/debug@4.1.12)(@types/node@26.1.2)(jiti@2.7.0)(jsdom@28.0.0(@noble/hashes@1.8.0))(tsx@4.23.1)(yaml@2.9.0))
       autoevals:
         specifier: ^0.3.0
         version: 0.3.0(@aws-sdk/credential-provider-node@3.972.77)(@smithy/signature-v4@5.6.12)(ws@8.21.1)(zod@3.25.76)
@@ -414,7 +414,7 @@ importers:
         version: 3.9.6
       promptfoo:
         specifier: ^0.121.20
-        version: 0.121.20(@aws-sdk/credential-provider-node@3.972.77)(@electric-sql/pglite@0.4.3)(@prisma/client@7.9.1(prisma@7.9.1(@types/react@19.2.17)(better-sqlite3@12.6.2)(magicast@0.3.5)(react-dom@19.2.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3))(@smithy/signature-v4@5.6.12)(@swc/helpers@0.5.23)(@types/json-schema@7.0.15)(@types/node@20.19.43)(@types/pg@8.20.3)(better-sqlite3@12.6.2)(mysql2@3.15.3)(pg@8.22.0)(playwright-core@1.61.1)(postgres@3.4.7)(prisma@7.9.1(@types/react@19.2.17)(better-sqlite3@12.6.2)(magicast@0.3.5)(react-dom@19.2.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(socks@2.8.7)
+        version: 0.121.20(@aws-sdk/credential-provider-node@3.972.77)(@electric-sql/pglite@0.4.3)(@prisma/client@7.9.1(prisma@7.9.1(@types/react@19.2.17)(better-sqlite3@12.6.2)(magicast@0.3.5)(react-dom@19.2.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3))(@smithy/signature-v4@5.6.12)(@swc/helpers@0.5.23)(@types/json-schema@7.0.15)(@types/node@26.1.2)(@types/pg@8.20.3)(better-sqlite3@12.6.2)(mysql2@3.15.3)(pg@8.22.0)(playwright-core@1.61.1)(postgres@3.4.7)(prisma@7.9.1(@types/react@19.2.17)(better-sqlite3@12.6.2)(magicast@0.3.5)(react-dom@19.2.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(socks@2.8.7)
       testcontainers:
         specifier: ^12.0.3
         version: 12.0.4
@@ -429,10 +429,10 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 3.2.6
-        version: 3.2.6(@types/debug@4.1.12)(@types/node@20.19.43)(jiti@2.7.0)(jsdom@28.0.0(@noble/hashes@1.8.0))(tsx@4.23.1)(yaml@2.9.0)
+        version: 3.2.6(@types/debug@4.1.12)(@types/node@26.1.2)(jiti@2.7.0)(jsdom@28.0.0(@noble/hashes@1.8.0))(tsx@4.23.1)(yaml@2.9.0)
       vitest-evals:
         specifier: ^0.15.0
-        version: 0.15.0(ai@6.0.231(zod@3.25.76))(tinyrainbow@2.0.0)(vitest@3.2.6(@types/debug@4.1.12)(@types/node@20.19.43)(jiti@2.7.0)(jsdom@28.0.0(@noble/hashes@1.8.0))(tsx@4.23.1)(yaml@2.9.0))(zod@3.25.76)
+        version: 0.15.0(ai@6.0.231(zod@3.25.76))(tinyrainbow@2.0.0)(vitest@3.2.6(@types/debug@4.1.12)(@types/node@26.1.2)(jiti@2.7.0)(jsdom@28.0.0(@noble/hashes@1.8.0))(tsx@4.23.1)(yaml@2.9.0))(zod@3.25.76)
       yaml:
         specifier: '>=2.8.3'
         version: 2.9.0
@@ -3077,14 +3077,14 @@ packages:
   '@types/node@18.19.80':
     resolution: {integrity: sha512-kEWeMwMeIvxYkeg1gTc01awpwLbfMRZXdIhwRcakd/KlK53jmRC26LqcbIt7fnAQTu5GzlnWmzA3H6+l1u6xxQ==}
 
-  '@types/node@20.19.43':
-    resolution: {integrity: sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==}
-
   '@types/node@22.20.1':
     resolution: {integrity: sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==}
 
   '@types/node@25.9.5':
     resolution: {integrity: sha512-OScDchr2fwuUmWdf4kZ9h7PcJiYDVInhJizG/biAq3cAvqwYktuy/TYGGdZNMtNTFUP7rnb0NU4TUdm82kt4Rg==}
+
+  '@types/node@26.1.2':
+    resolution: {integrity: sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==}
 
   '@types/nodemailer@8.0.1':
     resolution: {integrity: sha512-PxpaInm8V1JQDd4j0ds5HfvWQk8JupS1C0Picb96QJsrrRDjBH+DlK7L4ZdNSqNULhiZRQHc40nLVShaGxXAMw==}
@@ -7127,6 +7127,9 @@ packages:
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
+  undici-types@8.3.0:
+    resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
+
   undici@7.29.0:
     resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
@@ -8677,13 +8680,13 @@ snapshots:
   '@huggingface/tokenizers@0.1.3':
     optional: true
 
-  '@huggingface/transformers@4.2.0(@types/node@20.19.43)':
+  '@huggingface/transformers@4.2.0(@types/node@26.1.2)':
     dependencies:
       '@huggingface/jinja': 0.5.9
       '@huggingface/tokenizers': 0.1.3
       onnxruntime-node: 1.24.3
       onnxruntime-web: 1.26.0-dev.20260416-b7804b056c
-      sharp: 0.35.3(@types/node@20.19.43)
+      sharp: 0.35.3(@types/node@26.1.2)
     transitivePeerDependencies:
       - '@types/node'
     optional: true
@@ -8817,78 +8820,78 @@ snapshots:
 
   '@inquirer/ansi@2.0.7': {}
 
-  '@inquirer/checkbox@5.2.1(@types/node@20.19.43)':
+  '@inquirer/checkbox@5.2.1(@types/node@26.1.2)':
     dependencies:
       '@inquirer/ansi': 2.0.7
-      '@inquirer/core': 11.2.1(@types/node@20.19.43)
+      '@inquirer/core': 11.2.1(@types/node@26.1.2)
       '@inquirer/figures': 2.0.7
-      '@inquirer/type': 4.0.7(@types/node@20.19.43)
+      '@inquirer/type': 4.0.7(@types/node@26.1.2)
     optionalDependencies:
-      '@types/node': 20.19.43
+      '@types/node': 26.1.2
 
-  '@inquirer/confirm@6.1.1(@types/node@20.19.43)':
+  '@inquirer/confirm@6.1.1(@types/node@26.1.2)':
     dependencies:
-      '@inquirer/core': 11.2.1(@types/node@20.19.43)
-      '@inquirer/type': 4.0.7(@types/node@20.19.43)
+      '@inquirer/core': 11.2.1(@types/node@26.1.2)
+      '@inquirer/type': 4.0.7(@types/node@26.1.2)
     optionalDependencies:
-      '@types/node': 20.19.43
+      '@types/node': 26.1.2
 
-  '@inquirer/core@11.2.1(@types/node@20.19.43)':
+  '@inquirer/core@11.2.1(@types/node@26.1.2)':
     dependencies:
       '@inquirer/ansi': 2.0.7
       '@inquirer/figures': 2.0.7
-      '@inquirer/type': 4.0.7(@types/node@20.19.43)
+      '@inquirer/type': 4.0.7(@types/node@26.1.2)
       cli-width: 4.1.0
       fast-wrap-ansi: 0.2.2
       mute-stream: 3.0.0
       signal-exit: 4.1.0
     optionalDependencies:
-      '@types/node': 20.19.43
+      '@types/node': 26.1.2
 
-  '@inquirer/editor@5.2.2(@types/node@20.19.43)':
+  '@inquirer/editor@5.2.2(@types/node@26.1.2)':
     dependencies:
-      '@inquirer/core': 11.2.1(@types/node@20.19.43)
-      '@inquirer/external-editor': 3.0.3(@types/node@20.19.43)
-      '@inquirer/type': 4.0.7(@types/node@20.19.43)
+      '@inquirer/core': 11.2.1(@types/node@26.1.2)
+      '@inquirer/external-editor': 3.0.3(@types/node@26.1.2)
+      '@inquirer/type': 4.0.7(@types/node@26.1.2)
     optionalDependencies:
-      '@types/node': 20.19.43
+      '@types/node': 26.1.2
 
-  '@inquirer/external-editor@3.0.3(@types/node@20.19.43)':
+  '@inquirer/external-editor@3.0.3(@types/node@26.1.2)':
     dependencies:
       chardet: 2.1.1
       iconv-lite: 0.7.3
     optionalDependencies:
-      '@types/node': 20.19.43
+      '@types/node': 26.1.2
 
   '@inquirer/figures@2.0.7': {}
 
-  '@inquirer/input@5.1.2(@types/node@20.19.43)':
+  '@inquirer/input@5.1.2(@types/node@26.1.2)':
     dependencies:
-      '@inquirer/core': 11.2.1(@types/node@20.19.43)
-      '@inquirer/type': 4.0.7(@types/node@20.19.43)
+      '@inquirer/core': 11.2.1(@types/node@26.1.2)
+      '@inquirer/type': 4.0.7(@types/node@26.1.2)
     optionalDependencies:
-      '@types/node': 20.19.43
+      '@types/node': 26.1.2
 
-  '@inquirer/search@4.2.1(@types/node@20.19.43)':
+  '@inquirer/search@4.2.1(@types/node@26.1.2)':
     dependencies:
-      '@inquirer/core': 11.2.1(@types/node@20.19.43)
+      '@inquirer/core': 11.2.1(@types/node@26.1.2)
       '@inquirer/figures': 2.0.7
-      '@inquirer/type': 4.0.7(@types/node@20.19.43)
+      '@inquirer/type': 4.0.7(@types/node@26.1.2)
     optionalDependencies:
-      '@types/node': 20.19.43
+      '@types/node': 26.1.2
 
-  '@inquirer/select@5.2.1(@types/node@20.19.43)':
+  '@inquirer/select@5.2.1(@types/node@26.1.2)':
     dependencies:
       '@inquirer/ansi': 2.0.7
-      '@inquirer/core': 11.2.1(@types/node@20.19.43)
+      '@inquirer/core': 11.2.1(@types/node@26.1.2)
       '@inquirer/figures': 2.0.7
-      '@inquirer/type': 4.0.7(@types/node@20.19.43)
+      '@inquirer/type': 4.0.7(@types/node@26.1.2)
     optionalDependencies:
-      '@types/node': 20.19.43
+      '@types/node': 26.1.2
 
-  '@inquirer/type@4.0.7(@types/node@20.19.43)':
+  '@inquirer/type@4.0.7(@types/node@26.1.2)':
     optionalDependencies:
-      '@types/node': 20.19.43
+      '@types/node': 26.1.2
 
   '@ioredis/commands@1.10.0': {}
 
@@ -10478,7 +10481,7 @@ snapshots:
 
   '@slack/logger@5.0.0':
     dependencies:
-      '@types/node': 20.19.43
+      '@types/node': 26.1.2
     optional: true
 
   '@slack/types@3.0.0':
@@ -10488,7 +10491,7 @@ snapshots:
     dependencies:
       '@slack/logger': 5.0.0
       '@slack/types': 3.0.0
-      '@types/node': 20.19.43
+      '@types/node': 26.1.2
       '@types/retry': 0.12.0
       eventemitter3: 5.0.4
       p-queue: 6.6.2
@@ -10677,11 +10680,11 @@ snapshots:
 
   '@types/bcrypt@6.0.0':
     dependencies:
-      '@types/node': 20.19.43
+      '@types/node': 26.1.2
 
   '@types/bunyan@1.8.11':
     dependencies:
-      '@types/node': 20.19.43
+      '@types/node': 26.1.2
 
   '@types/caseless@0.12.5': {}
 
@@ -10692,11 +10695,11 @@ snapshots:
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 20.19.43
+      '@types/node': 26.1.2
 
   '@types/cors@2.8.19':
     dependencies:
-      '@types/node': 20.19.43
+      '@types/node': 26.1.2
 
   '@types/d3-array@3.0.3': {}
 
@@ -10737,13 +10740,13 @@ snapshots:
 
   '@types/docker-modem@3.0.6':
     dependencies:
-      '@types/node': 20.19.43
+      '@types/node': 26.1.2
       '@types/ssh2': 1.15.5
 
   '@types/dockerode@4.0.1':
     dependencies:
       '@types/docker-modem': 3.0.6
-      '@types/node': 20.19.43
+      '@types/node': 26.1.2
       '@types/ssh2': 1.15.5
 
   '@types/estree@1.0.9': {}
@@ -10755,7 +10758,7 @@ snapshots:
   '@types/jsonwebtoken@9.0.10':
     dependencies:
       '@types/ms': 2.1.0
-      '@types/node': 20.19.43
+      '@types/node': 26.1.2
 
   '@types/lodash@4.17.24': {}
 
@@ -10764,13 +10767,13 @@ snapshots:
 
   '@types/memcached@2.2.10':
     dependencies:
-      '@types/node': 20.19.43
+      '@types/node': 26.1.2
 
   '@types/ms@2.1.0': {}
 
   '@types/mysql@2.15.27':
     dependencies:
-      '@types/node': 20.19.43
+      '@types/node': 26.1.2
 
   '@types/node-cron@3.0.11': {}
 
@@ -10785,10 +10788,6 @@ snapshots:
       undici-types: 5.26.5
     optional: true
 
-  '@types/node@20.19.43':
-    dependencies:
-      undici-types: 6.21.0
-
   '@types/node@22.20.1':
     dependencies:
       undici-types: 6.21.0
@@ -10797,17 +10796,21 @@ snapshots:
     dependencies:
       undici-types: 7.24.6
 
+  '@types/node@26.1.2':
+    dependencies:
+      undici-types: 8.3.0
+
   '@types/nodemailer@8.0.1':
     dependencies:
-      '@types/node': 20.19.43
+      '@types/node': 26.1.2
 
   '@types/oracledb@6.5.2':
     dependencies:
-      '@types/node': 20.19.43
+      '@types/node': 26.1.2
 
   '@types/pdfkit@0.17.6':
     dependencies:
-      '@types/node': 20.19.43
+      '@types/node': 26.1.2
 
   '@types/pegjs@0.10.6':
     optional: true
@@ -10818,13 +10821,13 @@ snapshots:
 
   '@types/pg@8.15.6':
     dependencies:
-      '@types/node': 20.19.43
+      '@types/node': 26.1.2
       pg-protocol: 1.15.0
       pg-types: 2.2.0
 
   '@types/pg@8.20.3':
     dependencies:
-      '@types/node': 20.19.43
+      '@types/node': 26.1.2
       pg-protocol: 1.15.0
       pg-types: 2.2.0
 
@@ -10835,7 +10838,7 @@ snapshots:
   '@types/request@2.48.13':
     dependencies:
       '@types/caseless': 0.12.5
-      '@types/node': 20.19.43
+      '@types/node': 26.1.2
       '@types/tough-cookie': 4.0.5
       form-data: 4.0.6
 
@@ -10846,11 +10849,11 @@ snapshots:
 
   '@types/ssh2-streams@0.1.13':
     dependencies:
-      '@types/node': 20.19.43
+      '@types/node': 26.1.2
 
   '@types/ssh2@0.5.52':
     dependencies:
-      '@types/node': 20.19.43
+      '@types/node': 26.1.2
       '@types/ssh2-streams': 0.1.13
 
   '@types/ssh2@1.15.5':
@@ -10859,7 +10862,7 @@ snapshots:
 
   '@types/tedious@4.0.14':
     dependencies:
-      '@types/node': 20.19.43
+      '@types/node': 26.1.2
 
   '@types/tough-cookie@4.0.0':
     optional: true
@@ -10878,7 +10881,7 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 20.19.43
+      '@types/node': 26.1.2
 
   '@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)':
     dependencies:
@@ -11063,7 +11066,7 @@ snapshots:
     dependencies:
       '@vitest-evals/core': 0.15.0
 
-  '@vitest/coverage-v8@3.2.6(vitest@3.2.6(@types/debug@4.1.12)(@types/node@20.19.43)(jiti@2.7.0)(jsdom@28.0.0(@noble/hashes@1.8.0))(tsx@4.23.1)(yaml@2.9.0))':
+  '@vitest/coverage-v8@3.2.6(vitest@3.2.6(@types/debug@4.1.12)(@types/node@26.1.2)(jiti@2.7.0)(jsdom@28.0.0(@noble/hashes@1.8.0))(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -11078,7 +11081,7 @@ snapshots:
       std-env: 3.10.0
       test-exclude: 7.0.2
       tinyrainbow: 2.0.0
-      vitest: 3.2.6(@types/debug@4.1.12)(@types/node@20.19.43)(jiti@2.7.0)(jsdom@28.0.0(@noble/hashes@1.8.0))(tsx@4.23.1)(yaml@2.9.0)
+      vitest: 3.2.6(@types/debug@4.1.12)(@types/node@26.1.2)(jiti@2.7.0)(jsdom@28.0.0(@noble/hashes@1.8.0))(tsx@4.23.1)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -11090,13 +11093,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.6(vite@6.4.3(@types/node@20.19.43)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))':
+  '@vitest/mocker@3.2.6(vite@6.4.3(@types/node@26.1.2)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 3.2.6
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 6.4.3(@types/node@20.19.43)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
+      vite: 6.4.3(@types/node@26.1.2)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
 
   '@vitest/pretty-format@3.2.6':
     dependencies:
@@ -12148,7 +12151,7 @@ snapshots:
   engine.io@6.6.9:
     dependencies:
       '@types/cors': 2.8.19
-      '@types/node': 20.19.43
+      '@types/node': 26.1.2
       '@types/ws': 8.18.1
       accepts: 1.3.8
       base64id: 2.0.0
@@ -14371,17 +14374,17 @@ snapshots:
 
   promise-limit@2.7.0: {}
 
-  promptfoo@0.121.20(@aws-sdk/credential-provider-node@3.972.77)(@electric-sql/pglite@0.4.3)(@prisma/client@7.9.1(prisma@7.9.1(@types/react@19.2.17)(better-sqlite3@12.6.2)(magicast@0.3.5)(react-dom@19.2.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3))(@smithy/signature-v4@5.6.12)(@swc/helpers@0.5.23)(@types/json-schema@7.0.15)(@types/node@20.19.43)(@types/pg@8.20.3)(better-sqlite3@12.6.2)(mysql2@3.15.3)(pg@8.22.0)(playwright-core@1.61.1)(postgres@3.4.7)(prisma@7.9.1(@types/react@19.2.17)(better-sqlite3@12.6.2)(magicast@0.3.5)(react-dom@19.2.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(socks@2.8.7):
+  promptfoo@0.121.20(@aws-sdk/credential-provider-node@3.972.77)(@electric-sql/pglite@0.4.3)(@prisma/client@7.9.1(prisma@7.9.1(@types/react@19.2.17)(better-sqlite3@12.6.2)(magicast@0.3.5)(react-dom@19.2.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3))(@smithy/signature-v4@5.6.12)(@swc/helpers@0.5.23)(@types/json-schema@7.0.15)(@types/node@26.1.2)(@types/pg@8.20.3)(better-sqlite3@12.6.2)(mysql2@3.15.3)(pg@8.22.0)(playwright-core@1.61.1)(postgres@3.4.7)(prisma@7.9.1(@types/react@19.2.17)(better-sqlite3@12.6.2)(magicast@0.3.5)(react-dom@19.2.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(socks@2.8.7):
     dependencies:
       '@anthropic-ai/sdk': 0.112.3(zod@4.3.6)
       '@apidevtools/json-schema-ref-parser': 15.5.0(@types/json-schema@7.0.15)
-      '@inquirer/checkbox': 5.2.1(@types/node@20.19.43)
-      '@inquirer/confirm': 6.1.1(@types/node@20.19.43)
-      '@inquirer/core': 11.2.1(@types/node@20.19.43)
-      '@inquirer/editor': 5.2.2(@types/node@20.19.43)
-      '@inquirer/input': 5.1.2(@types/node@20.19.43)
-      '@inquirer/search': 4.2.1(@types/node@20.19.43)
-      '@inquirer/select': 5.2.1(@types/node@20.19.43)
+      '@inquirer/checkbox': 5.2.1(@types/node@26.1.2)
+      '@inquirer/confirm': 6.1.1(@types/node@26.1.2)
+      '@inquirer/core': 11.2.1(@types/node@26.1.2)
+      '@inquirer/editor': 5.2.2(@types/node@26.1.2)
+      '@inquirer/input': 5.1.2(@types/node@26.1.2)
+      '@inquirer/search': 4.2.1(@types/node@26.1.2)
+      '@inquirer/select': 5.2.1(@types/node@26.1.2)
       '@libsql/client': 0.17.4
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
@@ -14466,7 +14469,7 @@ snapshots:
       '@azure/storage-blob': 12.31.0
       '@fal-ai/client': 1.10.1
       '@googleapis/sheets': 13.0.1
-      '@huggingface/transformers': 4.2.0(@types/node@20.19.43)
+      '@huggingface/transformers': 4.2.0(@types/node@26.1.2)
       '@ibm-cloud/watsonx-ai': 1.7.15
       '@langfuse/client': 5.10.0(@opentelemetry/api@1.9.1)
       '@modelcontextprotocol/sdk': 1.30.0(zod@4.3.6)
@@ -14494,7 +14497,7 @@ snapshots:
       playwright: 1.61.1
       playwright-extra: 4.3.6(playwright-core@1.61.1)(playwright@1.61.1)
       read-excel-file: 9.3.3
-      sharp: 0.35.3(@types/node@20.19.43)
+      sharp: 0.35.3(@types/node@26.1.2)
     transitivePeerDependencies:
       - '@aws-sdk/client-rds-data'
       - '@aws-sdk/credential-provider-node'
@@ -14577,7 +14580,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.2
-      '@types/node': 20.19.43
+      '@types/node': 26.1.2
       long: 5.3.2
 
   protobufjs@8.7.1:
@@ -14965,7 +14968,7 @@ snapshots:
 
   setprototypeof@1.2.0: {}
 
-  sharp@0.35.3(@types/node@20.19.43):
+  sharp@0.35.3(@types/node@26.1.2):
     dependencies:
       '@img/colour': 1.1.0
       detect-libc: 2.1.2
@@ -14996,7 +14999,7 @@ snapshots:
       '@img/sharp-win32-arm64': 0.35.3
       '@img/sharp-win32-ia32': 0.35.3
       '@img/sharp-win32-x64': 0.35.3
-      '@types/node': 20.19.43
+      '@types/node': 26.1.2
     optional: true
 
   shebang-command@2.0.0:
@@ -15254,7 +15257,7 @@ snapshots:
 
   stripe@14.25.0:
     dependencies:
-      '@types/node': 20.19.43
+      '@types/node': 26.1.2
       qs: 6.15.3
 
   strnum@2.4.1:
@@ -15550,6 +15553,8 @@ snapshots:
 
   undici-types@7.24.6: {}
 
+  undici-types@8.3.0: {}
+
   undici@7.29.0: {}
 
   undici@8.9.0: {}
@@ -15622,13 +15627,13 @@ snapshots:
 
   version-range@4.15.0: {}
 
-  vite-node@3.2.4(@types/node@20.19.43)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0):
+  vite-node@3.2.4(@types/node@26.1.2)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.4.3(@types/node@20.19.43)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
+      vite: 6.4.3(@types/node@26.1.2)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -15643,7 +15648,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@6.4.3(@types/node@20.19.43)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0):
+  vite@6.4.3(@types/node@26.1.2)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0):
     dependencies:
       esbuild: 0.28.1
       fdir: 6.5.0(picomatch@4.0.5)
@@ -15652,27 +15657,27 @@ snapshots:
       rollup: 4.62.2
       tinyglobby: 0.2.17
     optionalDependencies:
-      '@types/node': 20.19.43
+      '@types/node': 26.1.2
       fsevents: 2.3.3
       jiti: 2.7.0
       tsx: 4.23.1
       yaml: 2.9.0
 
-  vitest-evals@0.15.0(ai@6.0.231(zod@3.25.76))(tinyrainbow@2.0.0)(vitest@3.2.6(@types/debug@4.1.12)(@types/node@20.19.43)(jiti@2.7.0)(jsdom@28.0.0(@noble/hashes@1.8.0))(tsx@4.23.1)(yaml@2.9.0))(zod@3.25.76):
+  vitest-evals@0.15.0(ai@6.0.231(zod@3.25.76))(tinyrainbow@2.0.0)(vitest@3.2.6(@types/debug@4.1.12)(@types/node@26.1.2)(jiti@2.7.0)(jsdom@28.0.0(@noble/hashes@1.8.0))(tsx@4.23.1)(yaml@2.9.0))(zod@3.25.76):
     dependencies:
       '@vitest-evals/core': 0.15.0
       '@vitest-evals/report-ui': 0.15.0
       tinyrainbow: 2.0.0
-      vitest: 3.2.6(@types/debug@4.1.12)(@types/node@20.19.43)(jiti@2.7.0)(jsdom@28.0.0(@noble/hashes@1.8.0))(tsx@4.23.1)(yaml@2.9.0)
+      vitest: 3.2.6(@types/debug@4.1.12)(@types/node@26.1.2)(jiti@2.7.0)(jsdom@28.0.0(@noble/hashes@1.8.0))(tsx@4.23.1)(yaml@2.9.0)
     optionalDependencies:
       ai: 6.0.231(zod@3.25.76)
       zod: 3.25.76
 
-  vitest@3.2.6(@types/debug@4.1.12)(@types/node@20.19.43)(jiti@2.7.0)(jsdom@28.0.0(@noble/hashes@1.8.0))(tsx@4.23.1)(yaml@2.9.0):
+  vitest@3.2.6(@types/debug@4.1.12)(@types/node@26.1.2)(jiti@2.7.0)(jsdom@28.0.0(@noble/hashes@1.8.0))(tsx@4.23.1)(yaml@2.9.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.6
-      '@vitest/mocker': 3.2.6(vite@6.4.3(@types/node@20.19.43)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+      '@vitest/mocker': 3.2.6(vite@6.4.3(@types/node@26.1.2)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
       '@vitest/pretty-format': 3.2.7
       '@vitest/runner': 3.2.6
       '@vitest/snapshot': 3.2.6
@@ -15690,12 +15695,12 @@ snapshots:
       tinyglobby: 0.2.17
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 6.4.3(@types/node@20.19.43)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
-      vite-node: 3.2.4(@types/node@20.19.43)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
+      vite: 6.4.3(@types/node@26.1.2)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
+      vite-node: 3.2.4(@types/node@26.1.2)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12
-      '@types/node': 20.19.43
+      '@types/node': 26.1.2
       jsdom: 28.0.0(@noble/hashes@1.8.0)
     transitivePeerDependencies:
       - jiti

--- a/api/src/network/tcp-dns-resolver.ts
+++ b/api/src/network/tcp-dns-resolver.ts
@@ -141,8 +141,11 @@ function tryServer(server: string, packet: Buffer, timeoutMs: number): Promise<B
       sock.write(packet);
     });
     sock.on('data', (chunk) => {
-      chunks.push(chunk);
-      received += chunk.length;
+      // Always a Buffer at runtime — this socket never calls setEncoding(),
+      // but the stream type widens to string | NonSharedBuffer regardless.
+      const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      chunks.push(buf);
+      received += buf.length;
       if (totalLen < 0 && received >= 2) {
         const buf = Buffer.concat(chunks);
         totalLen = buf.readUInt16BE(0);

--- a/api/src/providers/self-hosted/self-hosted-adapter.ts
+++ b/api/src/providers/self-hosted/self-hosted-adapter.ts
@@ -97,7 +97,9 @@ export class SelfHostedAdapter extends ProviderAdapter {
       const filename = (request.options?.filename as string) || 'audio.wav';
       form.set(
         'file',
-        new File([new Blob([request.audio], { type: mimeType })], filename, { type: mimeType })
+        new File([new Blob([new Uint8Array(request.audio)], { type: mimeType })], filename, {
+          type: mimeType,
+        })
       );
       if (request.language) form.set('language', request.language);
 

--- a/api/src/services/auth-service.ts
+++ b/api/src/services/auth-service.ts
@@ -449,16 +449,17 @@ export class AuthService {
       return null;
     }
 
-    // `createPublicKey` expects a `JsonWebKey` (structurally identical to our
-    // `FederatedJwk`, but defined in `node:crypto`). Building the object
+    // `createPublicKey` expects a `webcrypto.JsonWebKey` (structurally close
+    // to our `FederatedJwk`, but defined in `node:crypto`; notably it has no
+    // `kid` field — key-ID matching already happened in `selectFederatedJwk`
+    // above, so dropping it here doesn't lose anything). Building the object
     // explicitly here lets us drop the `as unknown as Record<string, string>`
     // cast — the previous code laundered the type through `unknown`, which
     // hides any real shape mismatch instead of catching it. With this shape,
     // tsc validates each field; if `FederatedJwk` ever drifts from the JWK
     // contract, the compiler tells us at the site instead of at runtime.
-    const jwkInput: import('crypto').JsonWebKey = {
+    const jwkInput: import('crypto').webcrypto.JsonWebKey = {
       kty: jwk.kty,
-      ...(jwk.kid !== undefined ? { kid: jwk.kid } : {}),
       ...(jwk.use !== undefined ? { use: jwk.use } : {}),
       ...(jwk.alg !== undefined ? { alg: jwk.alg } : {}),
       ...(jwk.n !== undefined ? { n: jwk.n } : {}),

--- a/api/src/services/service-token-verifier.ts
+++ b/api/src/services/service-token-verifier.ts
@@ -154,9 +154,10 @@ function selectJwk(keys: Jwk[], kid: string | undefined, alg: string): Jwk | nul
 }
 
 function toPublicKey(jwk: Jwk): Secret {
-  const jwkInput: import('crypto').JsonWebKey = {
+  // kid is intentionally omitted: webcrypto.JsonWebKey has no such field, and
+  // key-ID matching already happened in selectJwk() above.
+  const jwkInput: import('crypto').webcrypto.JsonWebKey = {
     kty: jwk.kty,
-    ...(jwk.kid !== undefined ? { kid: jwk.kid } : {}),
     ...(jwk.use !== undefined ? { use: jwk.use } : {}),
     ...(jwk.alg !== undefined ? { alg: jwk.alg } : {}),
     ...(jwk.n !== undefined ? { n: jwk.n } : {}),


### PR DESCRIPTION
Closes #46. Fixes the 4 `tsc --noEmit` errors that blocked the original `@types/node` 20 → 26.1.2 bump — all type-definition changes in the new package, unrelated to Node runtime version (confirmed on the Node 24 runner from #50, since the runtime doesn't matter here).

| File | Error | Fix |
|---|---|---|
| `tcp-dns-resolver.ts` | socket `'data'` chunk now types `string \| NonSharedBuffer` | `Buffer.isBuffer()` guard (socket never calls `setEncoding()`, always a Buffer at runtime) |
| `self-hosted-adapter.ts` | `Buffer<ArrayBufferLike>` no longer assignable to `BlobPart` (SharedArrayBuffer in the union) | wrap in `new Uint8Array(request.audio)` — copies into a fresh, guaranteed-plain-`ArrayBuffer` view |
| `auth-service.ts`, `service-token-verifier.ts` | `crypto.JsonWebKey` removed as a standalone export | switched to `crypto.webcrypto.JsonWebKey` (what `createPublicKey`'s `JsonWebKeyInput.key` now types as); that interface has no `kid` field, so dropped the `kid` spread |

**On dropping `kid`** (the auth-sensitive part): verified `kid`-based key *selection* already happens earlier in both call sites (`selectFederatedJwk` / `selectJwk`) — by the time the JWK object is built for `createPublicKey`, the right key is already chosen. `createPublicKey` itself never reads `kid` (confirmed against Node's native JWK-import source, which only dispatches on `kty` then reads type-specific material fields). Got an independent review pass on this specific claim before pushing; no issues found.

Verified: `tsc --noEmit` clean on a real Node 24.19.0 (fnm). Full suite passed clean in earlier Node-24 CI runs today (#50); local full-suite runs on this now heavily-loaded dev machine show unrelated flaky `beforeEach`-hook timeouts in broadcast route tests (untouched by this change) that pass 100% clean in isolation — letting the actual CI runner confirm.
